### PR TITLE
Implement commonjs build

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,32 +2,28 @@
     <img src="https://camo.githubusercontent.com/517483ae0eaba9884f397e9af1c4adc7bbc231575ac66cc54292e00400edcd10/68747470733a2f2f7777772e6d756c7469736166657061792e636f6d2f66696c6561646d696e2f74656d706c6174652f696d672f6d756c7469736166657061792d6c6f676f2d69636f6e2e737667" width="400px" position="center">
 </p>
 
-# Cross-platform ES6 module WebSocket plugin for the MultiSafepay API
+# Cross-platform WebSocket plugin for the MultiSafepay API
 
 This plugin simplifies working with the MultiSafepay API and lets you listen to the events received from your Payment Terminals.
 
-You can use this plugin in a Node.js backend based on ES6 or in any javascript frontend.
+You can use this plugin in a Node.js backend or in any javascript frontend.
 
 ## About MultiSafepay
 
 MultiSafepay is a Dutch payment service provider, which takes care of contracts, processing transactions, and collecting payment for a range of local and international payment methods. Start selling online today and manage all your transactions in one place!
-
-## Requirements
-
-- If using Node 8.0+, we recommend using async/await. For older versions of Node, use promises or callbacks instead of async/await.
 
 ## Installation
 
 With npm:
 
 ```sh
-npm install multisafepay/message-bus --save
+npm install @multisafepay/message-bus --save
 ```
 
 And yarn:
 
 ```sh
-yarn add multisafepay/message-bus
+yarn add @multisafepay/message-bus
 ```
 
 In case you want to use in plain HTML, you should have the code base of this plugin accesible, either at folder level or having the code deployed somewhere.
@@ -46,17 +42,28 @@ const { events_url, events_token } = orderResponse.data;
 const messageBus = connect(events_url, { token: events_token });
 ```
 
+Set up the client for testing with **CommonJS imports**:
+
+```javascript
+const connect = require('@multisafepay/message-bus').default;
+
+const { events_url, events_token } = orderResponse.data;
+
+const messageBus = connect(events_url, { token: events_token });
+```
+
 With **script tag**:
 
 ```html
  <script type="module">
-    import connect from `${PLUGIN_ROUTE}/src/browser/index.js`
+    import connect from `https://unpkg.com/@multisafepay/message-bus/dist/esm/browser/index.js`
 
     const { events_url, events_token } = orderResponse.data;
 
     const messageBus = connect(events_url, { token: events_token });
 </script>
 ```
+
 
 Subscribe to the order event:
 

--- a/fixType
+++ b/fixType
@@ -1,0 +1,11 @@
+cat >dist/cjs/package.json <<!EOF
+{
+    "type": "commonjs"
+}
+!EOF
+
+cat >dist/esm/package.json <<!EOF
+{
+    "type": "module"
+}
+!EOF

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@multisafepay/message-bus",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "rm -rf ./dist && npx tsc",
+    "build": "rm -rf ./dist && npx tsc && npx tsc --project tsconfig.es5.json && ./fixType",
     "prepare": "npm run build"
   },
   "type": "module",
@@ -17,17 +17,32 @@
       "license": "MIT"
     }
   ],
-  "main": "./dist/src/node/index.js",
-  "module": "./dist/src/node/index.js",
-  "browser": "./dist/src/browser/index.js",
+  "exports": {
+    ".": {
+      "require": {
+        "default": "./dist/cjs/node/index.js",
+        "types": "./dist/cjs/types/index.d.ts"
+      },
+      "browser": {
+        "default": "./dist/esm/browser/index.js"
+      },
+      "import": {
+        "default": "./dist/esm/node/index.js",
+        "types": "./dist/esm/types/index.d.ts"
+      }
+    }
+  },
+  "main": "./dist/cjs/node/index.js",
+  "types": "./dist/esm/types/index.d.ts",
+  "module": "./dist/esm/node/index.js",
+  "browser": "./dist/esm/browser/index.js",
   "dependencies": {
-    "typescript": "^5.1.3",
-    "tslib": "^2.5.3",
     "ws": "^8.13.0"
   },
   "devDependencies": {
     "@types/ws": "^8.5.5",
     "eslint": "^8.42.0",
-    "tslint-config-prettier": "^1.18.0"
+    "tslint-config-prettier": "^1.18.0",
+    "typescript": "^5.1.3"
   }
 }

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -20,6 +20,4 @@ if (typeof WebSocket !== 'undefined') {
  * @param customOptions 
  * @returns 
  */
-const messageBus = (endpoint: string, customOptions: customOptions) => wrapper(ws, endpoint, customOptions);
-
-export default messageBus;
+export default (endpoint: string, customOptions: customOptions) => wrapper(ws, endpoint, customOptions);

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -9,6 +9,4 @@ import { customOptions } from '../types/index.js';
  * @param customOptions 
  * @returns 
  */
-const messageBus = (endpoint: string, customOptions: customOptions) => wrapper(WebSocket, endpoint, customOptions);
-
-export default messageBus;
+export default (endpoint: string, customOptions: customOptions) => wrapper(WebSocket, endpoint, customOptions);

--- a/tsconfig.es5.json
+++ b/tsconfig.es5.json
@@ -5,8 +5,8 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "importHelpers": false,
-    "module": "ES6",
-    "moduleResolution": "node16",
+    "module": "CommonJS",
+    "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "noUnusedLocals": false,
@@ -15,9 +15,9 @@
     "removeComments": true,
     "resolveJsonModule": true,
     "strict": true,
-    "target": "ES6",
+    "target": "ES5",
     "rootDir": "src/",
-    "outDir": "dist/esm"
+    "outDir": "dist/cjs"
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
Now the package is available for javascript CommonJS modules.
I made some small optimizations on the previous build process
I added the modern way of exporting and type exporting on package.json
I removed the TSLIB library to be able to use this code on vanilla JS
I updated README to aim the npm published package instead of this repository and to aim to the "unpkg" version when using the script tag instead of having to deploy the code somewhere